### PR TITLE
docs: clarify orderbook websocket excludes AMM liquidity

### DIFF
--- a/docs/boros-dev-docs/Backend/4. websocket.mdx
+++ b/docs/boros-dev-docs/Backend/4. websocket.mdx
@@ -75,7 +75,7 @@ function cleanup() {
 
 | Channel | Event | Description |
 |---------|-------|-------------|
-| `orderbook:MARKET_ID:TICK_SIZE` | `orderbook:MARKET_ID:TICK_SIZE:update` | Orderbook updates. Accepted TICK_SIZE: `0.1`, `0.01`, `0.001`, `0.0001`, `0.00001` |
+| `orderbook:MARKET_ID:TICK_SIZE` | `orderbook:MARKET_ID:TICK_SIZE:update` | Orderbook updates — **orderbook liquidity only**, AMM liquidity is not included. Accepted TICK_SIZE: `0.1`, `0.01`, `0.001`, `0.0001`, `0.00001` |
 | `market-trade:MARKET_ID` | `market-trade:MARKET_ID:update` | Individual trade executions with `rate`, `size`, `blockTimestamp`, `txHash` |
 | `statistics:MARKET_ID` | `statistics:MARKET_ID:update` | Market statistics: `markApr`, `midApr`, `lastTradedApr`, `floatingApr`, `volume24h`, `notionalOI`, `nextSettlementTime`, `longYieldApr` |
 | `market-data:MARKET_ID` | `market-data-update` | Real-time market data from on-chain events. See [Market Data Events](#market-data-events) below. |


### PR DESCRIPTION
## Summary
- Note in the Boros WebSocket docs that the `orderbook:MARKET_ID:TICK_SIZE` channel now reflects orderbook liquidity only and no longer includes AMM liquidity.

## Test plan
- [ ] Render the Boros WebSocket docs page and confirm the orderbook channel description reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)