### PR TITLE
update SDK docs for v0.1.4 + bump CU rate-limit budget

### DIFF
--- a/docs/boros-dev-docs/Backend/10. computing-units.mdx
+++ b/docs/boros-dev-docs/Backend/10. computing-units.mdx
@@ -49,9 +49,7 @@ The endpoint always charges `N` CU per call regardless of parameters. Examples:
 
 The endpoint charges at least `N` (the minimum, billed for an empty / default request) and scales with the work performed. The actual cost is reported in the response header. Common scaling axes:
 
-- **Page size** — cursor-paginated list endpoints charge proportionally to **rows actually returned** (not the requested `limit`), so a caller passing `limit=1000` on a sub-account with 30 orders only pays for the 30 returned. Examples:
-  - `GET /v1/accounts/orders` — `max(1, ceil(results.length / 10))` (same pattern for `transfer-logs`, `gas-consumption-history`, `orders-by-placed-time`, `position-update-events`, `settlement-events`, `light-event-feed`, `markets/trades`).
-  - `GET /v1/events/liquidation-events` — still scales with the requested `limit`: `max(1, ceil(limit / 200))`.
+- **Page size** — list endpoints charge proportionally to `limit`. Example: `GET /v1/events/liquidation-events` is `max(1, ceil(limit / 200))`.
 - **Batch size** — multi-item endpoints charge 1 CU per 10 items. Example: `POST /v1/funding-rate/settlement-summary` is `max(1, ceil(settlementSummary.length / 10))`; `POST /v1/calldata-builder/agent/place-orders` is `max(1, ceil(orderRequests.length / 10))`.
 - **Number of indicators** — `GET /v1/indicators` charges 1 CU per indicator listed in `select`. A `udma:7;30` entry counts as one indicator regardless of how many windows are packed in.
 - **`maker` lookup flag** — `GET /v1/incentives/maker-incentives/campaigns/{marketId}` is 1 CU without `maker`, 2 CU with `maker`.

--- a/docs/boros-dev-docs/Backend/10. computing-units.mdx
+++ b/docs/boros-dev-docs/Backend/10. computing-units.mdx
@@ -49,7 +49,9 @@ The endpoint always charges `N` CU per call regardless of parameters. Examples:
 
 The endpoint charges at least `N` (the minimum, billed for an empty / default request) and scales with the work performed. The actual cost is reported in the response header. Common scaling axes:
 
-- **Page size** — list endpoints charge proportionally to `limit`. Example: `GET /v1/events/liquidation-events` is `max(1, ceil(limit / 200))`.
+- **Page size** — cursor-paginated list endpoints charge proportionally to **rows actually returned** (not the requested `limit`), so a caller passing `limit=1000` on a sub-account with 30 orders only pays for the 30 returned. Examples:
+  - `GET /v1/accounts/orders` — `max(1, ceil(results.length / 10))` (same pattern for `transfer-logs`, `gas-consumption-history`, `orders-by-placed-time`, `position-update-events`, `settlement-events`, `light-event-feed`, `markets/trades`).
+  - `GET /v1/events/liquidation-events` — still scales with the requested `limit`: `max(1, ceil(limit / 200))`.
 - **Batch size** — multi-item endpoints charge 1 CU per 10 items. Example: `POST /v1/funding-rate/settlement-summary` is `max(1, ceil(settlementSummary.length / 10))`; `POST /v1/calldata-builder/agent/place-orders` is `max(1, ceil(orderRequests.length / 10))`.
 - **Number of indicators** — `GET /v1/indicators` charges 1 CU per indicator listed in `select`. A `udma:7;30` entry counts as one indicator regardless of how many windows are packed in.
 - **`maker` lookup flag** — `GET /v1/incentives/maker-incentives/campaigns/{marketId}` is 1 CU without `maker`, 2 CU with `maker`.

--- a/docs/boros-dev-docs/Backend/10. computing-units.mdx
+++ b/docs/boros-dev-docs/Backend/10. computing-units.mdx
@@ -4,11 +4,22 @@ Every Open API endpoint advertises a per-call cost called a **Computing Unit (CU
 
 ## Budget
 
-**60 CU per minute per IP**, fixed window. Every successful call deducts its `x-computing-unit` cost from the bucket; the bucket refills every 60s.
+Two fixed-window buckets per IP, both must have capacity for a call to succeed:
 
-When the budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
+| Window | Limit |
+|---|---|
+| 1 minute | **200 CU** |
+| 1 week | **400,000 CU** |
 
-Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. There is currently no per-API-key tier — every consumer gets the same 60 CU/minute regardless of authentication.
+Every successful call deducts its `x-computing-unit` cost from both buckets. The minute bucket refills every 60s; the weekly bucket refills every 168h.
+
+When either budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
+
+Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. There is currently no per-API-key tier — every consumer gets the same limits regardless of authentication.
+
+:::info Need a higher limit?
+If your integration needs more than 200 CU/minute or 400,000 CU/week, please contact the Pendle team — higher tiers are available on request.
+:::
 
 ## Where CU is Reported
 

--- a/docs/boros-dev-docs/Backend/3. sdk.mdx
+++ b/docs/boros-dev-docs/Backend/3. sdk.mdx
@@ -64,13 +64,12 @@ new Exchange(walletClient, root, accountId, rpcUrls, agent?)
 
 `agent` is optional at construction time — set it later via `exchange.setAgent(agent)` if you bootstrap one with `Agent.create()` after the fact.
 
-The SDK ships with the production backend pre-wired (`api-boros.pendle.finance`, `api.boros.finance/send-txs-bot`). For staging, override at startup:
+The SDK ships with the production backend pre-wired (`api-boros.pendle.finance/apis`). All endpoints — markets, accounts, calldata builders, and send-txs — go through this single host. For staging, override at startup:
 
 ```ts
-import { setOpenApiBackendUrl, setSendTxsBotBackendUrl } from '@pendle/boros-sdk-public';
+import { setOpenApiBackendUrl } from '@pendle/boros-sdk-public';
 
 setOpenApiBackendUrl('https://staging-api-boros.pendle.finance/apis');
-setSendTxsBotBackendUrl('https://staging-api.boros.finance/send-txs-bot');
 ```
 
 ## Common flows
@@ -105,27 +104,23 @@ The SDK groups operations by who signs the calldata — root for sensitive actio
 
 ```ts
 import { Side, TimeInForce, MarketAccLib, CROSS_MARKET_ID } from '@pendle/boros-sdk-public';
-import { estimateTickForRate, FixedX18 } from '@pendle/boros-offchain-math';
 
 const market = (await exchange.getAllMarkets({ isUiWhitelisted: true }))[0];
 const marketAcc = MarketAccLib.pack(rootAccount.address, 0, market.tokenId, CROSS_MARKET_ID);
-
-// Convert your target APR into a contract-side tick using the market's tickStep.
-const targetApr = 0.05; // 5%
-const limitTick = Number(
-  estimateTickForRate(FixedX18.fromNumber(targetApr), BigInt(market.imData.tickStep), /* roundDown */ true),
-);
 
 const { result, executeResponse } = await exchange.placeOrder({
   marketAcc,
   marketId: market.marketId,
   side: Side.LONG,
   size: 10n ** 18n,
-  limitTick,
+  rate: 0.05,          // 5% APR — backend rounds to nearest valid tick
   tif: TimeInForce.GOOD_TIL_CANCELLED,
-  ammId: 0,            // 0 = orderbook-only; >0 = route through specific AMM
 });
 ```
+
+Pass `rate` (human-friendly decimal APR) or `limitTick` (raw integer tick) — **exactly one**. `rate` is the easy path; the backend rounds it to the nearest valid tick for the market. Use `limitTick` only if you've already computed the tick yourself (e.g. via `estimateTickForRate` from `@pendle/boros-offchain-math`).
+
+`ammId` is optional and defaults to orderbook-only routing. Pass a specific AMM id to route through that AMM instead.
 
 ### Place many orders in one transaction
 
@@ -256,8 +251,8 @@ Fresh integrators: skip this section. Lives here for users already wired up to t
 | Open API codegen namespace | `BorosBackend.Core` | `OpenApi` |
 | Open API accessor | `BorosBackend.getCoreSdk()` | `getOpenApiSdk()` |
 | Open API URL setter | `BorosBackend.setCoreBackendUrl(url)` | `setOpenApiBackendUrl(url)` |
-| Send Txs Bot accessor | `BorosBackend.getSendTxsBotSdk()` | `getSendTxsBotSdk()` |
-| Send Txs Bot URL setter | `BorosBackend.setSendTxsBotBackendUrl(url)` | `setSendTxsBotBackendUrl(url)` |
+| Send Txs Bot accessor | `BorosBackend.getSendTxsBotSdk()` | **removed** — use `getOpenApiSdk().sendTxs.*` |
+| Send Txs Bot URL setter | `BorosBackend.setSendTxsBotBackendUrl(url)` | **removed** — same host as Open API |
 | Default Open API base URL | `https://api.boros.finance/core` | `https://api-boros.pendle.finance/apis` |
 | Pendle V2 client | `BorosBackend.getPendleV2Sdk()` / `BorosBackend.setPendleV2BackendUrl()` | **removed** |
 | Structured-log client | `LogStoreBackend.*` namespace | **removed** |
@@ -324,10 +319,8 @@ BorosBackend.setCoreBackendUrl('https://staging-api.boros.finance/core');
 //                       ↓
 setOpenApiBackendUrl('https://staging-api-boros.pendle.finance/apis');
 
-// Send Txs Bot — function renamed, same prod URL
-BorosBackend.setSendTxsBotBackendUrl('https://staging-api.boros.finance/send-txs-bot');
-//                       ↓
-setSendTxsBotBackendUrl('https://staging-api.boros.finance/send-txs-bot');
+// Send Txs Bot — removed; send-txs is now part of the Open API host
+BorosBackend.setSendTxsBotBackendUrl(...);  // no replacement
 
 // Pendle V2 — removed
 BorosBackend.setPendleV2BackendUrl(...);  // no replacement
@@ -336,20 +329,21 @@ BorosBackend.setPendleV2BackendUrl(...);  // no replacement
 The `env`-driven prod/staging auto-switch from the old package is gone. Public SDK callers pass an explicit URL for staging; otherwise they inherit the production default baked into the package:
 
 ```ts
-OPEN_API_BACKEND_URL     = 'https://api-boros.pendle.finance/apis'
-SEND_TXS_BOT_BACKEND_URL = 'https://api.boros.finance/send-txs-bot'
+OPEN_API_BACKEND_URL = 'https://api-boros.pendle.finance/apis'
 ```
 
-**Send Txs Bot codegen client:** the `BorosBackend.SendTxsBot.Sdk` class is now exposed as the `SendTxsBot` top-level namespace. The wrapper interface was renamed `BorosSendTxsBotSdk` → `SendTxsBotSdk`. Generated payload types and method names are identical. Callers using the high-level `Exchange` methods (`placeOrder`, `bulkPlaceOrders`, `cancelOrders`, `payTreasury`, …) do not see this — `Exchange` continues to dispatch through the bot internally.
+**Send Txs Bot codegen client:** removed. The send-txs endpoints (`approve`, `trace`, `tx-status`, `tx-status-with-events`, `bulk-calls`, `dedicated/bulk-calls`) are folded into the Open API SDK under `sdk.sendTxs.*` and live on the same host. The `SendTxsBot` namespace, `SendTxsBotSdk` interface, `getSendTxsBotSdk()` accessor, and `setSendTxsBotBackendUrl()` are gone. Callers using the high-level `Exchange` methods (`placeOrder`, `bulkPlaceOrders`, `cancelOrders`, `payTreasury`, …) do not see this — `Exchange` continues to dispatch through the bot internally.
 
 ```ts
 // old
 import { BorosBackend } from '@pendle/sdk-boros';
 const bot = BorosBackend.getSendTxsBotSdk();
+await bot.agent.agentControllerBulkDirectCall({ /* ... */ });
 
 // new
-import { getSendTxsBotSdk, SendTxsBot } from '@pendle/boros-sdk-public';
-const bot = getSendTxsBotSdk();
+import { getOpenApiSdk } from '@pendle/boros-sdk-public';
+const sdk = getOpenApiSdk();
+await sdk.sendTxs.sendTxsControllerBulkCalls({ /* ... */ });
 ```
 
 ### Method-level changes {#migration-exchange-methods}
@@ -418,9 +412,9 @@ Symbol-for-symbol substitutions:
 BorosBackend.getCoreSdk()                  →  getOpenApiSdk()
 BorosBackend.Core.MarketListItemResponse   →  OpenApi.MarketListItemResponse
 BorosBackend.setCoreBackendUrl(url)        →  setOpenApiBackendUrl(url)
-BorosBackend.getSendTxsBotSdk()            →  getSendTxsBotSdk()
-BorosBackend.setSendTxsBotBackendUrl(url)  →  setSendTxsBotBackendUrl(url)
-BorosBackend.SendTxsBot.*                  →  SendTxsBot.*
+BorosBackend.getSendTxsBotSdk()            →  removed (use getOpenApiSdk().sendTxs.*)
+BorosBackend.setSendTxsBotBackendUrl(url)  →  removed (same host as Open API)
+BorosBackend.SendTxsBot.*                  →  removed (folded into OpenApi)
 BorosBackend.getPendleV2Sdk()              →  removed
 BorosBackend.setPendleV2BackendUrl(url)    →  removed
 LogStoreBackend.*                          →  removed

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -9887,13 +9887,12 @@ new Exchange(walletClient, root, accountId, rpcUrls, agent?)
 
 `agent` is optional at construction time — set it later via `exchange.setAgent(agent)` if you bootstrap one with `Agent.create()` after the fact.
 
-The SDK ships with the production backend pre-wired (`api-boros.pendle.finance`, `api.boros.finance/send-txs-bot`). For staging, override at startup:
+The SDK ships with the production backend pre-wired (`api-boros.pendle.finance/apis`). All endpoints — markets, accounts, calldata builders, and send-txs — go through this single host. For staging, override at startup:
 
 ```ts
-import { setOpenApiBackendUrl, setSendTxsBotBackendUrl } from '@pendle/boros-sdk-public';
+import { setOpenApiBackendUrl } from '@pendle/boros-sdk-public';
 
 setOpenApiBackendUrl('https://staging-api-boros.pendle.finance/apis');
-setSendTxsBotBackendUrl('https://staging-api.boros.finance/send-txs-bot');
 ```
 
 ## Common flows
@@ -9928,27 +9927,23 @@ The SDK groups operations by who signs the calldata — root for sensitive actio
 
 ```ts
 import { Side, TimeInForce, MarketAccLib, CROSS_MARKET_ID } from '@pendle/boros-sdk-public';
-import { estimateTickForRate, FixedX18 } from '@pendle/boros-offchain-math';
 
 const market = (await exchange.getAllMarkets({ isUiWhitelisted: true }))[0];
 const marketAcc = MarketAccLib.pack(rootAccount.address, 0, market.tokenId, CROSS_MARKET_ID);
-
-// Convert your target APR into a contract-side tick using the market's tickStep.
-const targetApr = 0.05; // 5%
-const limitTick = Number(
-  estimateTickForRate(FixedX18.fromNumber(targetApr), BigInt(market.imData.tickStep), /* roundDown */ true),
-);
 
 const { result, executeResponse } = await exchange.placeOrder({
   marketAcc,
   marketId: market.marketId,
   side: Side.LONG,
   size: 10n ** 18n,
-  limitTick,
+  rate: 0.05,          // 5% APR — backend rounds to nearest valid tick
   tif: TimeInForce.GOOD_TIL_CANCELLED,
-  ammId: 0,            // 0 = orderbook-only; >0 = route through specific AMM
 });
 ```
+
+Pass `rate` (human-friendly decimal APR) or `limitTick` (raw integer tick) — **exactly one**. `rate` is the easy path; the backend rounds it to the nearest valid tick for the market. Use `limitTick` only if you've already computed the tick yourself (e.g. via `estimateTickForRate` from `@pendle/boros-offchain-math`).
+
+`ammId` is optional and defaults to orderbook-only routing. Pass a specific AMM id to route through that AMM instead.
 
 ### Place many orders in one transaction
 
@@ -11195,11 +11190,22 @@ Every Open API endpoint advertises a per-call cost called a **Computing Unit (CU
 
 ## Budget
 
-**60 CU per minute per IP**, fixed window. Every successful call deducts its `x-computing-unit` cost from the bucket; the bucket refills every 60s.
+Two fixed-window buckets per IP, both must have capacity for a call to succeed:
 
-When the budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
+| Window | Limit |
+|---|---|
+| 1 minute | **200 CU** |
+| 1 week | **400,000 CU** |
 
-Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. There is currently no per-API-key tier — every consumer gets the same 60 CU/minute regardless of authentication.
+Every successful call deducts its `x-computing-unit` cost from both buckets. The minute bucket refills every 60s; the weekly bucket refills every 168h.
+
+When either budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
+
+Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. There is currently no per-API-key tier — every consumer gets the same limits regardless of authentication.
+
+:::info Need a higher limit?
+If your integration needs more than 200 CU/minute or 400,000 CU/week, please contact the Pendle team — higher tiers are available on request.
+:::
 
 ## Where CU is Reported
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -11235,7 +11235,9 @@ The endpoint always charges `N` CU per call regardless of parameters. Examples:
 
 The endpoint charges at least `N` (the minimum, billed for an empty / default request) and scales with the work performed. The actual cost is reported in the response header. Common scaling axes:
 
-- **Page size** — list endpoints charge proportionally to `limit`. Example: `GET /v1/events/liquidation-events` is `max(1, ceil(limit / 200))`.
+- **Page size** — cursor-paginated list endpoints charge proportionally to **rows actually returned** (not the requested `limit`), so a caller passing `limit=1000` on a sub-account with 30 orders only pays for the 30 returned. Examples:
+  - `GET /v1/accounts/orders` — `max(1, ceil(results.length / 10))` (same pattern for `transfer-logs`, `gas-consumption-history`, `orders-by-placed-time`, `position-update-events`, `settlement-events`, `light-event-feed`, `markets/trades`).
+  - `GET /v1/events/liquidation-events` — still scales with the requested `limit`: `max(1, ceil(limit / 200))`.
 - **Batch size** — multi-item endpoints charge 1 CU per 10 items. Example: `POST /v1/funding-rate/settlement-summary` is `max(1, ceil(settlementSummary.length / 10))`; `POST /v1/calldata-builder/agent/place-orders` is `max(1, ceil(orderRequests.length / 10))`.
 - **Number of indicators** — `GET /v1/indicators` charges 1 CU per indicator listed in `select`. A `udma:7;30` entry counts as one indicator regardless of how many windows are packed in.
 - **`maker` lookup flag** — `GET /v1/incentives/maker-incentives/campaigns/{marketId}` is 1 CU without `maker`, 2 CU with `maker`.

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -11235,9 +11235,7 @@ The endpoint always charges `N` CU per call regardless of parameters. Examples:
 
 The endpoint charges at least `N` (the minimum, billed for an empty / default request) and scales with the work performed. The actual cost is reported in the response header. Common scaling axes:
 
-- **Page size** — cursor-paginated list endpoints charge proportionally to **rows actually returned** (not the requested `limit`), so a caller passing `limit=1000` on a sub-account with 30 orders only pays for the 30 returned. Examples:
-  - `GET /v1/accounts/orders` — `max(1, ceil(results.length / 10))` (same pattern for `transfer-logs`, `gas-consumption-history`, `orders-by-placed-time`, `position-update-events`, `settlement-events`, `light-event-feed`, `markets/trades`).
-  - `GET /v1/events/liquidation-events` — still scales with the requested `limit`: `max(1, ceil(limit / 200))`.
+- **Page size** — list endpoints charge proportionally to `limit`. Example: `GET /v1/events/liquidation-events` is `max(1, ceil(limit / 200))`.
 - **Batch size** — multi-item endpoints charge 1 CU per 10 items. Example: `POST /v1/funding-rate/settlement-summary` is `max(1, ceil(settlementSummary.length / 10))`; `POST /v1/calldata-builder/agent/place-orders` is `max(1, ceil(orderRequests.length / 10))`.
 - **Number of indicators** — `GET /v1/indicators` charges 1 CU per indicator listed in `select`. A `udma:7;30` entry counts as one indicator regardless of how many windows are packed in.
 - **`maker` lookup flag** — `GET /v1/incentives/maker-incentives/campaigns/{marketId}` is 1 CU without `maker`, 2 CU with `maker`.


### PR DESCRIPTION
## Summary

- **SDK docs ([3. sdk.mdx](docs/boros-dev-docs/Backend/3.%20sdk.mdx))** — reflect recent `@pendle/boros-sdk-public` changes:
  - `getSendTxsBotSdk()` / `setSendTxsBotBackendUrl()` / `SendTxsBot` namespace removed (consolidated into `OpenApiSdk` per [`86b480d`](https://github.com/pendle-finance/boros-sdk/commit/86b480d)). Send-txs endpoints now live under `getOpenApiSdk().sendTxs.*`.
  - `Exchange.placeOrder` now accepts `rate` (APR) directly (v0.1.3, [`b489ccd`](https://github.com/pendle-finance/boros-sdk/commit/b489ccd)). Updated the limit-order example to drop manual `estimateTickForRate(...)`.
  - `ammId` is now optional in `PlaceOrderParams` ([`be7146c`](https://github.com/pendle-finance/boros-sdk/commit/be7146c)) — removed from the example.
- **Computing Units ([10. computing-units.mdx](docs/boros-dev-docs/Backend/10.%20computing-units.mdx))** — replace the 60 CU/min budget with the new buckets: **200 CU/minute** and **400,000 CU/168h (1 week)**, both enforced per IP. Added a note pointing higher-volume integrators to the Pendle team.
- Regenerated [`static/llms-full.txt`](static/llms-full.txt).

## Test plan

- [ ] Render docs locally (`yarn start`) and skim the SDK + CU pages for layout/link sanity
- [ ] Confirm the rewritten place-order snippet compiles against `@pendle/boros-sdk-public@0.1.4`