### PR TITLE
docs(boros): simplify rate-limit section and document API dashboard

### DIFF
--- a/docs/boros-dev-docs/Backend/10. computing-units.mdx
+++ b/docs/boros-dev-docs/Backend/10. computing-units.mdx
@@ -15,11 +15,43 @@ Every successful call deducts its `x-computing-unit` cost from both buckets. The
 
 When either budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
 
-Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. There is currently no per-API-key tier — every consumer gets the same limits regardless of authentication.
+Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. Unauthenticated requests share the per-IP free-tier budget above; authenticated requests are billed against the paid plan attached to the API key (see below).
 
-:::info Need a higher limit?
-If your integration needs more than 200 CU/minute or 400,000 CU/week, please contact the Pendle team — higher tiers are available on request.
-:::
+### Endpoint-Specific Throttles
+
+A few endpoints have additional per-IP throttles on top of the CU budget:
+
+| Endpoint | Extra throttle |
+|----------|----------------|
+| `GET /v1/indicators/export` | 3 requests/minute/IP |
+
+## Higher Rate Limits via API Key
+
+If your integration needs more than the per-IP free-tier limits, paid plans are available through the **[Boros API Dashboard](https://api-boros.pendle.finance/dashboard)**.
+
+### Getting an API key
+
+1. Go to [https://api-boros.pendle.finance/dashboard](https://api-boros.pendle.finance/dashboard)
+2. Connect your wallet and sign the verification message to log in
+3. Choose a plan and create a new API key
+
+Save the generated key securely — you'll need it to authenticate your requests.
+
+### Using your API key
+
+Include your key as a Bearer token in the `Authorization` header on every request:
+
+```
+Authorization: Bearer <API_KEY>
+```
+
+**Example:**
+```bash
+curl -i -H "Authorization: Bearer your_api_key_here" \
+  https://api-boros.pendle.finance/apis/v1/markets
+```
+
+Authenticated requests are billed against your plan's higher limits instead of the per-IP free-tier budget.
 
 ## Where CU is Reported
 

--- a/docs/boros-dev-docs/Backend/10. computing-units.mdx
+++ b/docs/boros-dev-docs/Backend/10. computing-units.mdx
@@ -15,8 +15,6 @@ Every successful call deducts its `x-computing-unit` cost from both buckets. The
 
 When either budget is exhausted the API returns **HTTP 429** with body `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. Wait for the next window before retrying.
 
-Cloudflare-fronted requests are bucketed by `cf-connecting-ip`; direct requests by remote IP. Same-origin browsers behind a NAT share one bucket. Unauthenticated requests share the per-IP free-tier budget above; authenticated requests are billed against the paid plan attached to the API key (see below).
-
 ### Endpoint-Specific Throttles
 
 A few endpoints have additional per-IP throttles on top of the CU budget:

--- a/docs/boros-dev-docs/Backend/4. api.mdx
+++ b/docs/boros-dev-docs/Backend/4. api.mdx
@@ -439,27 +439,7 @@ See [Best Practices](./6.%20best-practices.mdx) for error handling recommendatio
 
 ## Rate Limiting
 
-Every IP gets a budget of **60 Computing Units (CU) per minute**, fixed window. Each endpoint advertises its CU cost via the `x-computing-unit` response header and the OpenAPI `x-computing-unit` extension. Most read endpoints are 1 CU.
-
-Exceeding the budget returns **HTTP 429** with `{ "statusCode": 429, "message": "ThrottlerException: Too Many Requests" }`. The bucket refills at the start of the next 60-second window.
-
-A few endpoints have additional per-IP throttles on top of the CU budget:
-
-| Endpoint | Extra throttle |
-|----------|----------------|
-| `GET /v1/indicators/export` | 3 requests/minute/IP |
-
-Recommendations to stay under budget:
-
-- Use [WebSocket](./5.%20websocket.mdx) for real-time data instead of polling.
-- Batch where possible: `POST /v1/accounts/market-acc-infos` accepts up to 100 `marketAccs`, `GET /v1/markets/by-ids` accepts comma-separated IDs, `POST /v1/calldata-builder/agent/place-orders` accepts an array.
-- Cache market and asset data that doesn't change frequently.
-
-See [Computing Units](./10.%20computing-units.mdx) for the per-endpoint cost table.
-
-## Computing Units
-
-Every Open API endpoint advertises a per-call cost via the `x-computing-unit` extension on the OpenAPI spec, also returned as the `x-computing-unit` HTTP response header on every successful request. Most endpoints cost **1 CU**; some scale dynamically with page size, market count, or number of indicators requested. See [Computing Units](./10.%20computing-units.mdx) for the full model.
+Boros uses a **Computing Unit (CU)** based rate-limit system — every endpoint advertises a per-call cost, and per-IP budgets apply. See [Computing Units](./10.%20computing-units.mdx) for budgets, per-endpoint costs, headers, and API-key tiers.
 
 ---
 


### PR DESCRIPTION
## Summary

- Collapse the duplicated **Rate Limiting** + **Computing Units** sections in [`4. api.mdx`](docs/boros-dev-docs/Backend/4.%20api.mdx) into a single pointer to the dedicated [`10. computing-units.mdx`](docs/boros-dev-docs/Backend/10.%20computing-units.mdx) doc. This also removes the stale "60 CU/minute" figure (the canonical doc says **200 CU/minute**).
- Move the endpoint-specific throttle table (currently just `GET /v1/indicators/export` → 3 req/min/IP) from `4. api.mdx` into a new **Endpoint-Specific Throttles** subsection of `10. computing-units.mdx`, next to the per-IP budget.
- Add a new **Higher Rate Limits via API Key** section to `10. computing-units.mdx` that points to the new [Boros API Dashboard](https://api-boros.pendle.finance/dashboard), with the wallet-login flow for generating a key and the `Authorization: Bearer <API_KEY>` usage pattern. Replaces the older "contact the Pendle team" callout.

## Test plan

- [ ] Render `docs/boros-dev-docs/Backend/4. api.mdx` locally and confirm the Rate Limiting section is now a single pointer paragraph
- [ ] Render `docs/boros-dev-docs/Backend/10. computing-units.mdx` locally and confirm the Endpoint-Specific Throttles subsection and Higher Rate Limits / API Key section render correctly
- [ ] Verify the `./10.%20computing-units.mdx` link from `4. api.mdx` resolves
- [ ] Verify the [dashboard link](https://api-boros.pendle.finance/dashboard) is reachable
- [ ] Sanity-check that no other doc still cites the old "60 CU/minute" or "contact the Pendle team" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)