### PR TITLE
chore(ci): upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20 # Use a recommended Node.js version (Docusaurus requires >= 18)


### PR DESCRIPTION
## Summary

Upgrade `actions/checkout` to `@v6` in this repo's GitHub workflows. Major-tag pin — this repo's workflows are read-only after checkout (no follow-up git push, no laterally-capable secrets), so no SHA pin needed.

## Why

GitHub removes Node.js 20 from hosted runners in **September 2026** (force-default to Node 24 on June 2, 2026). `actions/checkout@v4` and older majors run on Node 20 and will stop working. `@v6` runs on Node 24.

## What changed

`.github/workflows/deploy.yaml` — version-pin bump from `@v4` to `@v6`.

## Sweep tracking

Part of a workspace-wide sweep across 15 Pendle repos.

## Test plan

- [ ] CI passes on this PR
- [ ] No `actions/checkout` deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)